### PR TITLE
Dockerfile: added inotify-tools to package install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     flex \
     g++ \
     git-core \
+    inotify-tools \
     libtool \
     lua5.3 \
     make \


### PR DESCRIPTION
This adds inotifywait and other utilities used by scripts that we want
to test.