### PR TITLE
Dockerfile: added packages from firmware-specific toolchains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,14 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     sudo \
     wget \
   && rm --recursive --force /var/lib/apt/lists/* \
-  && wget --quiet -O /tmp/cmake.sh https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh \
-    && sh /tmp/cmake.sh --prefix=/usr/local --exclude-subdir --skip-license \
-    && rm /tmp/cmake.sh \
-  && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
-  && pip --no-cache-dir install conan==1.0.4
+  && pip --no-cache-dir install conan==1.0.4 \
+  && ln -sf /usr/bin/lua5.3 /usr/bin/lua
+
+RUN mkdir /src \
+  && wget --quiet -O /src/cmake.sh https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh \
+    && sh /src/cmake.sh --prefix=/usr/local --exclude-subdir --skip-license \
+  && cd / \
+  && rm --recursive --force /src
 
 ENV HOME=/home/captain \
   CONAN_PRINT_RUN_COMMANDS=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,30 +2,79 @@ FROM ubuntu:16.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --yes --no-install-recommends \
+    apt-transport-https \
+    autoconf \
     automake \
+    autopoint \
+    bc \
     bison \
+    ca-certificates \
+    ccache \
+    curl \
     flex \
     g++ \
+    gawk \
+    gcc \
+    gettext \
     git-core \
+    gperf \
+    groff \
     inotify-tools \
+    intltool \
+    kmod \
+    liblist-moreutils-perl \
+    liblzo2-dev \
     libtool \
+    libxml-dom-perl \
+    libxml2-utils \
     lua5.3 \
     make \
+    net-tools \
+    nodejs \
     openssh-client \
     pkg-config \
     python \
+    python-m2crypto \
     python-pip \
     python-setuptools \
     python-wheel \
+    rsync \
+    scons \
     sudo \
+    texinfo \
+    u-boot-tools \
+    uuid-dev \
     wget \
+    xutils-dev \
+    xz-utils \
+    zip \
+    zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && pip --no-cache-dir install conan==1.0.4 \
-  && ln -sf /usr/bin/lua5.3 /usr/bin/lua
+  && ln -sf /bin/bash /bin/sh \
+  && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
+  && ln -sf /usr/bin/nodejs /usr/bin/node
 
 RUN mkdir /src \
   && wget --quiet -O /src/cmake.sh https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh \
     && sh /src/cmake.sh --prefix=/usr/local --exclude-subdir --skip-license \
+  && git clone https://github.com/wsbu/cross-browser.git \
+      --branch x419_z1 --depth 1 /src/crossbrowser \
+    && cd /src/crossbrowser/x/xc \
+    && gcc -c xc.c -O2 \
+    && gcc -o xc xc.o -O2 \
+    && cp --force xc /bin \
+    && strip /bin/xc \
+    && mkdir --parents /lib/crossbrowser \
+    && cp --archive /src/crossbrowser/x/lib/*.js /lib/crossbrowser \
+    && cp --archive /src/crossbrowser/x/lib/old/*.js /lib/crossbrowser \
+  && git clone https://github.com/wsbu/mtd-utils.git \
+      --branch v2.0.1  --depth 1 /src/mtd-utils \
+    && cd /src/mtd-utils \
+    && ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install \
   && cd / \
   && rm --recursive --force /src
 


### PR DESCRIPTION
This provides a base toolchain image that can be used for pipeline
testing individual repositories. Now, the -linaro and -arm9 toolchains
need to add little more than the cross compiler. Any pipeline tests run
using this generic -native toolchain will run in an environment similar
to the environment present for a target-specific firmware build.

These packages aren't necessarily hardware specific (only arm9 gets the
32-bit libs packages, and only linaro gets the qemu emulator), so it makes sense to include them in a common base.