### PR TITLE
Add fakeroot to native.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     ca-certificates \
     ccache \
     curl \
+    fakeroot \
     flex \
     g++ \
     gawk \


### PR DESCRIPTION
switchcode uses fakeroot to be able to set a bunch of perms on the
files it packs into a tarball for the default config.