### PR TITLE
Add the most recent golang, and some symlinks to make it usable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     gcc \
     gettext \
     git-core \
+    golang-1.10 \
     gperf \
     groff \
     inotify-tools \
@@ -58,7 +59,10 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   && pip --no-cache-dir install conan==1.3.0 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
-  && ln -sf /usr/bin/nodejs /usr/bin/node
+  && ln -sf /usr/bin/nodejs /usr/bin/node \
+  && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \
+  && ln -sf /usr/lib/go-1.10/bin/go /usr/bin/go
+
 
 RUN mkdir /src \
   && wget --quiet -O /src/cmake.sh https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh \


### PR DESCRIPTION
golang-1.10 is in backports, which is already in the sources.list, so
it was just a matter of installing it.