### PR TITLE
Bump ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && npm install -g showdown \
-  && pip --no-cache-dir install conan==1.3.0 \
+  && pip --no-cache-dir install conan==1.4.4 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/bin/nodejs /usr/bin/node \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --yes --no-install-recommends \

--- a/conan/profile
+++ b/conan/profile
@@ -5,7 +5,7 @@ arch=x86_64
 platform=x86_64
 arch_build=x86_64
 compiler=gcc
-compiler.version=5
+compiler.version=7
 compiler.libcxx=libstdc++11
 build_type=Release
 [options]

--- a/conan/profile
+++ b/conan/profile
@@ -2,11 +2,12 @@
 os=Linux
 os_build=Linux
 arch=x86_64
-platform=x86_64
 arch_build=x86_64
 compiler=gcc
 compiler.version=7
 compiler.libcxx=libstdc++11
 build_type=Release
+platform=x86_64
 [options]
+[build_requires]
 [env]

--- a/conan/registry.txt
+++ b/conan/registry.txt
@@ -1,3 +1,2 @@
 conan-center https://conan.bintray.com True
-conan-transit https://conan-transit.bintray.com True
 ci http://ci.redlion.net:8040/artifactory/api/conan/conan-local True

--- a/conan/settings.yml
+++ b/conan/settings.yml
@@ -1,6 +1,7 @@
+
 # Only for cross building, 'os_build/arch_build' is the system that runs Conan
 os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS]
-arch_build: [x86, x86_64]
+arch_build: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
 
 # Only for building cross compilation tools, 'os_target/arch_target' is the system for
 # which the tools generate code
@@ -37,9 +38,10 @@ compiler:
         libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
     gcc:
         version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
-                  "5", "5.1", "5.2", "5.3", "5.4",
+                  "5", "5.1", "5.2", "5.3", "5.4", "5.5",
                   "6", "6.1", "6.2", "6.3", "6.4",
-                  "7", "7.1", "7.2"]
+                  "7", "7.1", "7.2", "7.3",
+                  "8", "8.1"]
         libcxx: [libstdc++, libstdc++11]
         threads: [None, posix, win32] #  Windows MinGW
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW
@@ -48,11 +50,12 @@ compiler:
         version: ["8", "9", "10", "11", "12", "14", "15"]
         toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp, v140, v140_xp, v140_clang_c2, LLVM-vs2014, LLVM-vs2014_xp, v141, v141_xp, v141_clang_c2]
     clang:
-        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "5.0"]
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "5.0", "6.0", "7.0"]
         libcxx: [libstdc++, libstdc++11, libc++]
     apple-clang:
-        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0"]
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1"]
         libcxx: [libstdc++, libc++]
 
-build_type: [None, Debug, Release]
+build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
 platform: [sitara, btg25, x86_64]

--- a/docker-native
+++ b/docker-native
@@ -20,5 +20,5 @@ docker run -it --rm \
     -v "${dir}:/opt/project" \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-native:v0.1.4 "$@"
+    wsbu/toolchain-native:v0.1.6 "$@"
 


### PR DESCRIPTION
Depends on #11 

The time has arrived for building a TeamCity build agent Docker image, and to ensure that TeamCity can build all of our stuff, it's easiest if that Docker image is built on top of toolchain-native. However, when building native, it'd be great if it was also building with the latest compiler that many developers are already using. The result is that x86 Conan binary artifacts being provided by the CI server will see higher utilization and therefore developer compile times will decrease (they'll be reusing existing binaries from the CI server instead of building their own).