### PR TITLE
Conan's registry file needs to have correct permissions

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -19,9 +19,10 @@ if [ "${uid}" -a "${gid}" ] ; then
             ${user_name}
     fi
     if ((1000 != ${uid} || 1000 != ${gid} )) ; then
-        chown ${uid}:${gid} $HOME
-        chown ${uid}:${gid} $HOME/.ssh
+        chown ${uid}:${gid} "${HOME}"
+        chown ${uid}:${gid} "${HOME}/.ssh"
     fi
+    chown ${uid}:${gid} "${HOME}/.conan/registry.txt"
     su_cmd="sudo --preserve-env --user ${user_name}"
     set +e
 fi


### PR DESCRIPTION
Conan's registry file was previously owned by root (because it was typically created by root at the top of the start script) and was breaking Conan things. No one noticed before now because me, Lance, and TeamCity are the only ones using Conan. Me and Lance don't use Docker with Conan, and TeamCity was using an old version of this image that was unaffected until recently.