### PR TITLE
Update Conan and CMake to latest versions; Also add .bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && npm install -g showdown \
-  && pip --no-cache-dir install conan==1.4.4 \
+  && pip --no-cache-dir install conan==1.6.1 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \
@@ -68,7 +68,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
 
 
 RUN mkdir /src \
-  && wget --quiet -O /src/cmake.sh https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh \
+  && wget --quiet -O /src/cmake.sh https://cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.sh \
     && sh /src/cmake.sh --prefix=/usr/local --exclude-subdir --skip-license \
   && git clone https://github.com/wsbu/cross-browser.git \
       --branch x419_z1 --depth 1 /src/crossbrowser \
@@ -97,13 +97,11 @@ COPY conan/settings.yml "${HOME}/.conan/settings.yml"
 COPY conan/registry.txt "${HOME}/.conan/registry.template.txt"
 
 RUN groupadd --gid 1000 captain \
-  && useradd --home-dir "$HOME" \
-    --uid 1000 --gid 1000 \
-    captain \
-  && mkdir --parents \
-    $HOME/.ssh \
-  && chown --recursive captain:captain "$HOME" \
-  && chmod --recursive 777 "$HOME" \
+  && useradd --home-dir "${HOME}" --uid 1000 --gid 1000 captain \
+  && mkdir --parents "${HOME}/.ssh" \
+  && cp /root/.bashrc /root/.profile "${HOME}" \
+  && chown --recursive captain:captain "${HOME}" \
+  && chmod --recursive 777 "${HOME}" \
   && echo "ALL ALL=NOPASSWD: ALL" >> /etc/sudoers
 
 

--- a/conan/settings.yml
+++ b/conan/settings.yml
@@ -1,12 +1,12 @@
 
 # Only for cross building, 'os_build/arch_build' is the system that runs Conan
 os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS]
-arch_build: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
+arch_build: [x86, x86_64, ppc64le, ppc64, armv5te, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
 
 # Only for building cross compilation tools, 'os_target/arch_target' is the system for
 # which the tools generate code
 os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, Arduino]
-arch_target: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
+arch_target: [x86, x86_64, ppc64le, ppc64, armv5te, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
 
 # Rest of the settings are "host" settings:
 # - For native building/cross building: Where the library/program will run.
@@ -30,14 +30,14 @@ os:
     SunOS:
     Arduino:
         board: ANY
-arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
+arch: [x86, x86_64, ppc64le, ppc64, armv5te, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
 compiler:
     sun-cc:
         version: ["5.10", "5.11", "5.12", "5.13", "5.14"]
         threads: [None, posix]
         libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
     gcc:
-        version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
+        version: ["4.1", "4.2", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
                   "5", "5.1", "5.2", "5.3", "5.4", "5.5",
                   "6", "6.1", "6.2", "6.3", "6.4",
                   "7", "7.1", "7.2", "7.3",

--- a/docker-native
+++ b/docker-native
@@ -22,4 +22,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/registry.txt:/home/captain/.conan/registry.txt" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-native:v0.2.2 "$@"
+    wsbu/toolchain-native:v0.2.4 "$@"


### PR DESCRIPTION
CMake v3.12 brings some great new features, including importable targets for CURL (something that will make wsbu-libs' build system simpler).

But mostly I'm submitting this PR because I got tired of not having all the nice stuff provided by Ubuntu's default `.bashrc` file, and this PR fixes it.