### PR TITLE
Dockerfile: added python3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     python-pip \
     python-setuptools \
     python-wheel \
+    python3.6 \
     rsync \
     scons \
     sudo \


### PR DESCRIPTION
This is needed to compile latest python for our devices.

I tried replacing all of the python things with python3, but python 2 ended up being installed anyways.