### PR TITLE
Add support for Go's dep dependency manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \
-  && ln -sf /usr/lib/go-1.10/bin/go /usr/bin/go
+  && ln -sf /usr/lib/go-1.10/bin/go /usr/bin/go \
+  && wget https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -O /usr/local/bin/dep \
+  && chmod +x /usr/local/bin/dep
 
 
 RUN mkdir /src \

--- a/docker-native
+++ b/docker-native
@@ -22,4 +22,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/registry.txt:/home/captain/.conan/registry.txt" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-native:v0.2.4 "$@"
+    wsbu/toolchain-native:v0.2.5 "$@"


### PR DESCRIPTION
Dorn and I are moving along with our research in Go as the language of choice for SVM 4 and adding dep will allow us to (more easily) start building our projects in TeamCity.