### PR TITLE
Conan registry now includes another common Conan remote

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && npm install -g showdown \
-  && pip --no-cache-dir install conan==1.7.3 \
+  && pip --no-cache-dir install conan==1.7.4 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \

--- a/conan/registry.txt
+++ b/conan/registry.txt
@@ -1,2 +1,3 @@
 conan-center https://conan.bintray.com True
 ci https://artifactory.redlion.net/artifactory/api/conan/conan-local True
+bintray-community https://api.bintray.com/conan/conan-community/conan True

--- a/docker-native
+++ b/docker-native
@@ -22,4 +22,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/registry.txt:/home/captain/.conan/registry.txt" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-native:v0.2.6 "$@"
+    wsbu/toolchain-native:v0.2.7 "$@"


### PR DESCRIPTION
IODB started using catch which only exists in the newly added Conan remote. Need it added to our docker images too.