### PR TITLE
start.sh|docker-native: updated user handling - v0.2.8

### DIFF
--- a/docker-native
+++ b/docker-native
@@ -22,4 +22,4 @@ docker run -it --rm \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/registry.txt:/home/captain/.conan/registry.txt" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-native:v0.2.7 "$@"
+    wsbu/toolchain-native:v0.2.8 "$@"

--- a/start.sh
+++ b/start.sh
@@ -1,29 +1,31 @@
 #!/usr/bin/env bash
 
+# Note: set user using `--env uid=XXXX --env gid=XXXX`, instead of using
+# docker's `--user` flag
+
 if [ ! -s "${HOME}/.conan/registry.txt" ] ; then
     cat "${HOME}/.conan/registry.template.txt" >> "${HOME}/.conan/registry.txt"
 fi
 
 if [ "${uid}" -a "${gid}" ] ; then
     set -e
-    user_name=$(basename ${HOME})
-    if (( 1000 != ${gid} )) ; then
-        groupadd --gid ${gid} ${user_name}
+    if ! grep --quiet ":${gid}:" /etc/group; then
+        groupadd --gid "${gid}" cocaptain
     fi
-    if (( 1000 != ${uid} )) ; then
+    if ! grep --quiet ":x:${uid}:" /etc/passwd; then
         useradd \
             --home-dir "$HOME" \
             --uid ${uid} \
             --gid ${gid} \
             --groups sudo \
-            ${user_name}
+            cocaptain
     fi
     if ((1000 != ${uid} || 1000 != ${gid} )) ; then
         chown ${uid}:${gid} "${HOME}"
         chown ${uid}:${gid} "${HOME}/.ssh"
     fi
     chown ${uid}:${gid} "${HOME}/.conan/registry.txt"
-    su_cmd="sudo --preserve-env --user ${user_name}"
+    su_cmd="sudo --preserve-env --user #${uid} --group #${gid}"
     set +e
 fi
 


### PR DESCRIPTION
user_name was populated by an already-existing user with an
already-existing home directory. We want to re-use the home directory,
but we need to create a new user (and optionally group) to associate with
the input IDs.

https://redlion.atlassian.net/browse/PP-891