### PR TITLE
Dockerfile: install GNU time - v0.1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     scons \
     sudo \
     texinfo \
+    time \
     u-boot-tools \
     uuid-dev \
     w3m \

--- a/docker-native
+++ b/docker-native
@@ -20,4 +20,4 @@ docker run -it --rm \
     -v "${dir}:/opt/project" \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-native:v0.1.6 "$@"
+    wsbu/toolchain-native:v0.1.7 "$@"


### PR DESCRIPTION
This gives many more (see: any) options over standard-issue shell time,
specifically to let us generate more parse-able timestamps for
build-time metrics.

E.g.:

    # /usr/bin/time --format "sleep took this long: %E" sleep 1
    sleep took this long: 0:01.00

https://redlion.atlassian.net/browse/MS-4260