### PR TITLE
Conan made some annoying changes in v1.9 that require more updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,6 @@ ENV HOME=/home/captain \
   CONAN_PRINT_RUN_COMMANDS=1
 COPY conan/profile "${HOME}/.conan/profiles/default"
 COPY conan/settings.yml "${HOME}/.conan/settings.yml"
-COPY conan/registry.txt "${HOME}/.conan/registry.template.txt"
 
 RUN groupadd --gid 1000 captain \
   && useradd --home-dir "${HOME}" --uid 1000 --gid 1000 captain \

--- a/conan/registry.txt
+++ b/conan/registry.txt
@@ -1,3 +1,0 @@
-conan-center https://conan.bintray.com True
-ci https://artifactory.redlion.net/artifactory/api/conan/conan-local True
-bintray-community https://api.bintray.com/conan/conan-community/conan True

--- a/docker-native
+++ b/docker-native
@@ -13,13 +13,13 @@ touch ~/.conan/registry.json
 set -x
 docker run -it --rm \
     --net=host \
-    -w "/opt/project" \
     -e uid="${uid}" \
     -e gid="${gid}" \
     -v "$HOME/.ssh/id_rsa:/home/captain/.ssh/id_rsa" \
     -v "$HOME/.ssh/known_hosts:/home/captain/.ssh/known_hosts" \
-    -v "${dir}:/opt/project" \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
     -v "$HOME/.conan/registry.json:/home/captain/.conan/registry.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
+    -v "${dir}:${dir}" \
+    -w "${dir}" \
     wsbu/toolchain-native:v0.3.0 "$@"

--- a/docker-native
+++ b/docker-native
@@ -8,7 +8,7 @@ set -e
 
 mkdir --parents ~/.conan/data
 touch ~/.conan/.conan.db
-touch ~/.conan/registry.txt
+touch ~/.conan/registry.json
 
 set -x
 docker run -it --rm \
@@ -20,6 +20,6 @@ docker run -it --rm \
     -v "$HOME/.ssh/known_hosts:/home/captain/.ssh/known_hosts" \
     -v "${dir}:/opt/project" \
     -v "$HOME/.conan/data:/home/captain/.conan/data" \
-    -v "$HOME/.conan/registry.txt:/home/captain/.conan/registry.txt" \
+    -v "$HOME/.conan/registry.json:/home/captain/.conan/registry.json" \
     -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
-    wsbu/toolchain-native:v0.2.9 "$@"
+    wsbu/toolchain-native:v0.3.0 "$@"

--- a/start.sh
+++ b/start.sh
@@ -3,12 +3,6 @@
 # Note: set user using `--env uid=XXXX --env gid=XXXX`, instead of using
 # docker's `--user` flag
 
-if [[ ! -s "${HOME}/.conan/registry.json" ]] ; then
-    conan remote add ci "https://artifactory.redlion.net/artifactory/api/conan/conan-local"
-    conan remote add conan-center "https://conan.bintray.com"
-    conan remote add bintray-community "https://api.bintray.com/conan/conan-community/conan"
-fi
-
 if [[ "${uid}" && "${gid}" ]] ; then
     set -e
     if ! grep --quiet ":${gid}:" /etc/group; then

--- a/start.sh
+++ b/start.sh
@@ -3,11 +3,13 @@
 # Note: set user using `--env uid=XXXX --env gid=XXXX`, instead of using
 # docker's `--user` flag
 
-if [ ! -s "${HOME}/.conan/registry.txt" ] ; then
-    cat "${HOME}/.conan/registry.template.txt" >> "${HOME}/.conan/registry.txt"
+if [[ ! -s "${HOME}/.conan/registry.json" ]] ; then
+    conan remote add ci "https://artifactory.redlion.net/artifactory/api/conan/conan-local"
+    conan remote add conan-center "https://conan.bintray.com"
+    conan remote add bintray-community "https://api.bintray.com/conan/conan-community/conan"
 fi
 
-if [ "${uid}" -a "${gid}" ] ; then
+if [[ "${uid}" && "${gid}" ]] ; then
     set -e
     if ! grep --quiet ":${gid}:" /etc/group; then
         groupadd --gid "${gid}" cocaptain
@@ -24,7 +26,7 @@ if [ "${uid}" -a "${gid}" ] ; then
         chown ${uid}:${gid} "${HOME}"
         chown ${uid}:${gid} "${HOME}/.ssh"
     fi
-    chown ${uid}:${gid} "${HOME}/.conan/registry.txt"
+    chown ${uid}:${gid} "${HOME}/.conan/registry.json"
     su_cmd="sudo --preserve-env --user #${uid} --group #${gid}"
     set +e
 fi


### PR DESCRIPTION
FYI: Conan v1.9 switched from a registry.txt to a registry.json file and tries to automatically upgrade. As part of that upgrade, it will try to _remove_ your old .txt file. If the .txt file is mounted in a Docker container, Conan will completely fail to run. So... make sure you upgrade your _native_ Conan instance (`sudo -H pip3 install --upgrade conan`) and then run Conan (no args necessary, just `conan` will do) to perform the upgrade on your host before invoking any Docker/Conan builds.