### PR TITLE
Use latest version of Conan, with remotes.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && npm install -g showdown \
-  && pip3 --no-cache-dir install conan==1.15.1 \
+  && pip3 --no-cache-dir install conan==1.16.0 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \
@@ -92,6 +92,7 @@ RUN groupadd --gid 1000 captain \
   && useradd --home-dir "${HOME}" --uid 1000 --gid 1000 captain \
   && mkdir --parents "${HOME}/.ssh" \
   && cp /root/.bashrc /root/.profile "${HOME}" \
+  && conan config set general.revisions_enabled=True \
   && chown --recursive captain:captain "${HOME}" \
   && chmod --recursive 777 "${HOME}" \
   && echo "ALL ALL=NOPASSWD: ALL" >> /etc/sudoers

--- a/docker-native
+++ b/docker-native
@@ -7,19 +7,30 @@ dir="$(pwd)"
 set -e
 
 mkdir --parents ~/.conan/data
-touch ~/.conan/.conan.db
-touch ~/.conan/registry.json
+
+if [[ ! -e "${HOME}/.conan/.conan.db" ]] ; then
+    echo "Conan database (~/.conan/.conan.db) does not exist. Please initialize Conan for your host system first."
+    exit 1
+fi
+if [[ ! -e "${HOME}/.conan/remotes.json" ]] ; then
+    if [[ -e "${HOME}/.conan/registry.json" ]] ; then
+        echo "This version of the Docker image contains a different version of Conan than your most recently used version. Please use your host-installed version of Conan to migrate and then try again."
+    else
+        echo "Conan database (~/.conan/remotes) does not exist. Please initialize Conan for your host system first."
+    fi
+    exit 1
+fi
 
 set -x
 docker run -it --rm \
     --net=host \
     -e uid="${uid}" \
     -e gid="${gid}" \
-    -v "$HOME/.ssh/id_rsa:/home/captain/.ssh/id_rsa" \
-    -v "$HOME/.ssh/known_hosts:/home/captain/.ssh/known_hosts" \
-    -v "$HOME/.conan/data:/home/captain/.conan/data" \
-    -v "$HOME/.conan/registry.json:/home/captain/.conan/registry.json" \
-    -v "$HOME/.conan/.conan.db:/home/captain/.conan/.conan.db" \
+    -v "${HOME}/.ssh/id_rsa:/home/captain/.ssh/id_rsa" \
+    -v "${HOME}/.ssh/known_hosts:/home/captain/.ssh/known_hosts" \
+    -v "${HOME}/.conan/data:/home/captain/.conan/data" \
+    -v "${HOME}/.conan/remotes.json:/home/captain/.conan/remotes.json" \
+    -v "${HOME}/.conan/.conan.db:/home/captain/.conan/.conan.db" \
     -v "${dir}:${dir}" \
     -w "${dir}" \
-    wsbu/toolchain-native:v0.3.3 "$@"
+    wsbu/toolchain-native:v0.3.4 "$@"


### PR DESCRIPTION
This is required to support Conan revisions and the new "virtual" conan repository in Artifactory, which aggregates our homegrown artifact repo with local caches of two public repos all into a single URL.

I also improved the `docker-native` script to make it less likely that a user will screw up their Conan configuration by doing bad things with Docker.