### PR TITLE
[MAN-1574] Upgrade Conan v1.16.0 -> v1.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && npm install -g showdown \
-  && pip3 --no-cache-dir install conan==1.16.0 \
+  && pip3 --no-cache-dir install conan==1.16.1 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \

--- a/docker-native
+++ b/docker-native
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "${HOME}/.conan/.conan.db:/home/captain/.conan/.conan.db" \
     -v "${dir}:${dir}" \
     -w "${dir}" \
-    wsbu/toolchain-native:v0.3.4 "$@"
+    wsbu/toolchain-native:v0.3.5 "$@"


### PR DESCRIPTION
This fixes https://github.com/conan-io/conan/issues/5329, necessary
for building the Linux kernel