### PR TITLE
[MAN-1750] Upgrade conan to support lockfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && npm install -g showdown \
-  && pip3 --no-cache-dir install conan==1.19.2 \
+  && pip3 --no-cache-dir install conan==1.20.3 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \

--- a/docker-native
+++ b/docker-native
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "${HOME}/.conan/.conan.db:/home/captain/.conan/.conan.db" \
     -v "${dir}:${dir}" \
     -w "${dir}" \
-    wsbu/toolchain-native:v0.3.7 "$@"
+    wsbu/toolchain-native:v0.3.8 "$@"


### PR DESCRIPTION
This pulls in the fix from https://github.com/conan-io/conan/issues/5499, allowing us to use lockfiles in base.