### PR TITLE
[PP-993] Add gcov and gcovr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     g++ \
     gawk \
     gcc \
+    gcov \
+    gcovr \
     gettext \
     git-core \
     golang-1.10 \

--- a/docker-native
+++ b/docker-native
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "${HOME}/.conan/.conan.db:/home/captain/.conan/.conan.db" \
     -v "${dir}:${dir}" \
     -w "${dir}" \
-    wsbu/toolchain-native:v0.3.8 "$@"
+    wsbu/toolchain-native:v0.3.9 "$@"


### PR DESCRIPTION
I'm very close to having code coverage, valgrind, and unit test reports on SonarQube. This will let me include the coverage reports part of that.