### PR TITLE
[MAN-1750] Bump Conan for lockfile fix; Add clang-tidy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     bison \
     ca-certificates \
     ccache \
+    clang-tidy \
     curl \
     docbook-xml \
     docbook-xsl \
@@ -62,7 +63,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     zlib1g-dev \
   && rm --recursive --force /var/lib/apt/lists/* \
   && npm install -g showdown \
-  && pip3 --no-cache-dir install conan==1.20.3 \
+  && pip3 --no-cache-dir install conan==1.21.0 \
   && ln -sf /bin/bash /bin/sh \
   && ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/lib/go-1.10/bin/gofmt /usr/bin/gofmt \

--- a/docker-native
+++ b/docker-native
@@ -33,4 +33,4 @@ docker run -it --rm \
     -v "${HOME}/.conan/.conan.db:/home/captain/.conan/.conan.db" \
     -v "${dir}:${dir}" \
     -w "${dir}" \
-    wsbu/toolchain-native:v0.3.9 "$@"
+    wsbu/toolchain-native:v0.3.10 "$@"


### PR DESCRIPTION
This. Finally, this.

Conan had lockfiles before, but with a critical bug (they changed every time you generated the lockfile, even if you didn't change anything else). That has now been fixed with the release of v1.21.0.

While waiting for that fix, I've also been working on SonarQube and am close to getting clang-tidy results uploaded as part of builds. That will require having clang-tidy available, which means adding it to this Docker image.